### PR TITLE
Use git tag name instead of git ref for target dir in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,5 @@ jobs:
           install -d -m 700 ~/.ssh/
           echo "${{secrets.target_host}} ${{secrets.ssh_host_fingerprint}}">~/.ssh/known_hosts
           echo "${{secrets.ssh_private_key}}" >~/.ssh/id_ed25519 && chmod 600 ~/.ssh/id_ed25519
-      - run: rsync -a --delete -v www loader dist rando-widget@${{secrets.target_host}}:public_html/$GITHUB_REF/
+      - run: rsync -a --delete -v www loader dist rando-widget@${{secrets.target_host}}:public_html/$GITHUB_REF_NAME/
       - run: ssh rando-widget@${{secrets.target_host}} ln -sf $GITHUB_REF public_html/latest


### PR DESCRIPTION
It should fix deployment error on nonexistent directory.